### PR TITLE
Amtron 4 you 5 xx fix enable disable firmware bug

### DIFF
--- a/charger/bender.go
+++ b/charger/bender.go
@@ -119,7 +119,7 @@ func NewBenderCC(ctx context.Context, uri string, id uint8) (api.Charger, error)
 		wb.legacy = true
 		wb.model = "bender"
 	} else {
-		if strings.Contains(strings.ToLower(string(bModel[:])), "4you") || 
+		if strings.Contains(strings.ToLower(string(bModel[:])), "4you") ||
 			strings.Contains(strings.ToLower(string(bModel[:])), "4business") {
 			wb.model = "4you"
 		}
@@ -231,21 +231,39 @@ func (wb *BenderCC) Enable(enable bool) error {
 		_, err := wb.conn.WriteMultipleRegisters(bendRegHemsCurrentLimit, 1, b)
 
 		return err
+
 	} else {
+
 		powerlimit, err1 := wb.CalculatePowerLimit(wb.current)
 
 		if err1 != nil {
 			return fmt.Errorf("error calculating power limit: %v", err1)
 		}
 
-		b := make([]byte, 2)
+		bp := make([]byte, 2)
 		if enable {
-			binary.BigEndian.PutUint16(b, uint16(powerlimit))
+			binary.BigEndian.PutUint16(bp, uint16(powerlimit))
+		} else {
+			binary.BigEndian.PutUint16(bp, uint16(0))
 		}
 
-		_, err := wb.conn.WriteMultipleRegisters(amtronRegHemsPowerLimit, 1, b)
+		_, err_p := wb.conn.WriteMultipleRegisters(amtronRegHemsPowerLimit, 1, bp)
 
-		return err
+		if err_p != nil {
+			return fmt.Errorf("Error setting HEMS Power Limit: %v", err_p)
+		}
+
+		bc := make([]byte, 2)
+		if enable {
+			binary.BigEndian.PutUint16(bc, uint16(16))
+		} else {
+			binary.BigEndian.PutUint16(bc, uint16(0))
+		}
+
+		_, err_c := wb.conn.WriteMultipleRegisters(bendRegHemsCurrentLimit, 1, bc)
+
+		return err_c
+
 	}
 }
 


### PR DESCRIPTION
Wie besprochen der Fix, der "unbestimmte" States in dem "HEMS Current Register" nach reboots oder timeouts von der WB abfangen soll.
Vom Prinzip wird einfach bei enable() HEMS Current auf 16A gesetzt und HEMS Power auf die berechnete Leistung, bei Disable HEMS Current und HEMS Power auf 0.

So werden Werte, wie z.B. der Rückfallstrom beim timeout der WB dann überschrieben und limitieren nicht die Power.
Andererseits erfolgt das Setzen von HEMS Current mit 16A nur wenn die Power, die ja durchaus kleiner als 16A sein kann, erfolgreich war. Damit ist dann "HEMS Power" der limitierende Faktor und evtl. "max current" settings in der evcc GUI werden berücksichtigt, da diese in die "HEMS Power" Berechnung einfließen.